### PR TITLE
Auth-definitions below ldap are a hash, not an array

### DIFF
--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -151,7 +151,7 @@ when 'debian', 'ubuntu' then
   # ldap
   ruby_block 'package-dovecot-ldap' do
     block {}
-    only_if do node['dovecot']['auth']['ldap'].kind_of?(Array) and node['dovecot']['auth']['ldap'].length > 0 end
+    only_if do node['dovecot']['auth']['ldap'].kind_of?(Hash) and node['dovecot']['auth']['ldap'].length > 0 end
     notifies :install, 'package[dovecot-ldap]', :immediately
     node['dovecot']['conf_files']['ldap'].each do |conf_file|
       notifies :create, "template[#{conf_file}]", :immediately


### PR DESCRIPTION
While using this cookbook to set up a dovecot authenticating against an AD I wondered the following didn't make it install dovecot-ldap (I like using symbols in my recipes):

``` ruby
node.default[:dovecot][:auth][:ldap][:passdb][:args] = '/etc/dovecot/dovecot-ldap.conf.ext'
node.default[:dovecot][:auth][:ldap][:userdb][:args] = '/etc/dovecot/dovecot-ldap.conf.ext'
```

This patch fixes this.

The patch could even be simplified by writing

``` ruby
only_if node['dovecot']['auth'].fetch('ldap', {}).length > 0
```
