### PR TITLE
Added mail_max_userip_connections attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,6 +896,26 @@ Also used by LMTP.
   </tr>
 </table>
 
+## Maximum number of connections/IP address
+
+* Configuration files:
+  * `conf.d/20-imap.conf`
+  * `conf.d/20-managesieve.conf`
+  * `conf.d/20-pop3.conf`
+
+<table>
+  <tr>
+    <th>Attribute</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><code>node['dovecot']['conf']['mail_max_userip_connections']</code></td>
+    <td>Used to limit the number of connections allowed from the same IP address. Inserted into multiple configuration files (imap, pop3, managesieve)</td>
+    <td><em>nil</em></td>
+  </tr>
+</table>
+
 ## Berkeley DB DB_CONFIG attributes
 
 * Configuration file: `dovecot-db.conf.ext`.

--- a/attributes/conf-multifile.rb
+++ b/attributes/conf-multifile.rb
@@ -1,0 +1,7 @@
+
+# conf.d/20-imap.conf
+# conf.d/20-managesieve.conf
+# conf.d/20-pop3.conf
+
+default['dovecot']['conf']['mail_max_userip_connections'] = nil
+

--- a/metadata.rb
+++ b/metadata.rb
@@ -1168,6 +1168,17 @@ attribute 'dovecot/conf/lmtp_save_to_detail_mailbox',
   :required => 'optional',
   :default => 'nil'
 
+# conf.d/20-imap.conf
+# conf.d/20-managesieve.conf
+# conf.d/20-pop3.conf
+
+attribute 'dovecot/conf/mail_max_userip_connections',
+  :display_name => 'Maximum number of open connections for each IP address',
+  :description => 'Used to limit the number of connections allowed from the same IP address. Inserted into multiple configuration files (imap, pop3, managesieve)',
+  :type => 'string',
+  :required => 'optional',
+  :default => 'nil'
+
 #
 # dovecot-db.conf.ext
 #

--- a/templates/default/conf.d/20-imap.conf.erb
+++ b/templates/default/conf.d/20-imap.conf.erb
@@ -15,7 +15,7 @@ protocol imap {
 
   # Maximum number of IMAP connections allowed for a user from each IP address.
   # NOTE: The username is compared case-sensitively.
-  #mail_max_userip_connections = 10
+  <%= Dovecot::Conf.attribute(@conf, 'mail_max_userip_connections', 10) %>
 
   # Space separated list of plugins to load (default is global mail_plugins).
   #mail_plugins = $mail_plugins

--- a/templates/default/conf.d/20-managesieve.conf.erb
+++ b/templates/default/conf.d/20-managesieve.conf.erb
@@ -54,7 +54,7 @@ protocol sieve {
   # Maximum number of ManageSieve connections allowed for a user from each IP
   # address.
   # NOTE: The username is compared case-sensitively.
-  #mail_max_userip_connections = 10
+  <%= Dovecot::Conf.attribute(@conf, 'mail_max_userip_connections', 10) %>
 
   # Space separated list of plugins to load (none known to be useful so far).
   # Do NOT try to load IMAP plugins here.

--- a/templates/default/conf.d/20-pop3.conf.erb
+++ b/templates/default/conf.d/20-pop3.conf.erb
@@ -74,7 +74,7 @@ protocol pop3 {
 
   # Maximum number of POP3 connections allowed for a user from each IP address.
   # NOTE: The username is compared case-sensitively.
-  #mail_max_userip_connections = 10
+  <%= Dovecot::Conf.attribute(@conf, 'mail_max_userip_connections', 10) %>
 
   # Space separated list of plugins to load (default is global mail_plugins).
   #mail_plugins = $mail_plugins


### PR DESCRIPTION
Added a new attribute which was burnt-in to the config file templates. The only speciality is that it appears across multiple config files with the same key, so it cannot be set separately using the `Dovecot::Conf` library.
