### PR TITLE
Add support for ssl_dh config

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ To see a more complete description of the attributes, go to the [Dovecot wiki2 c
 | `node['dovecot']['conf']['ssl_verify_client_cert']`    | *nil*        | Request client to send a certificate.
 | `node['dovecot']['conf']['ssl_cert_username_field']`   | *nil*        | Which field from certificate to use for username.
 | `node['dovecot']['conf']['ssl_parameters_regenerate']` | *nil*        | How often to regenerate the SSL parameters file.
+| `node['dovecot']['conf']['ssl_dh']`                    | *nil*        | DH parameters to use. Generate new params with `openssl dhparam -out /etc/dovecot/dh.pem 4096`
 | `node['dovecot']['conf']['ssl_dh_parameters_length']`  | *nil*        | DH parameters length to use.
 | `node['dovecot']['conf']['ssl_protocols']`             | *nil*        | SSL protocols to use.
 | `node['dovecot']['conf']['ssl_cipher_list']`           | *nil*        | SSL ciphers to use.

--- a/attributes/conf_10_ssl.rb
+++ b/attributes/conf_10_ssl.rb
@@ -64,6 +64,7 @@ default['dovecot']['conf']['ssl_verify_client_cert'] = nil
 default['dovecot']['conf']['ssl_cert_username_field'] = nil
 default['dovecot']['conf']['ssl_parameters_regenerate'] = nil
 default['dovecot']['conf']['ssl_dh_parameters_length'] = nil
+default['dovecot']['conf']['ssl_dh'] = nil
 default['dovecot']['conf']['ssl_protocols'] = nil
 default['dovecot']['conf']['ssl_cipher_list'] = nil
 default['dovecot']['conf']['ssl_prefer_server_ciphers'] = nil

--- a/templates/default/conf.d/10-ssl.conf.erb
+++ b/templates/default/conf.d/10-ssl.conf.erb
@@ -64,6 +64,12 @@
 # DH parameters length to use.
 <%= DovecotCookbook::Conf.attribute(@conf, 'ssl_dh_parameters_length', 1024) %>
 
+# SSL DH parameters
+# Generate new params with `openssl dhparam -out /etc/dovecot/dh.pem 4096`
+# Or migrate from old ssl-parameters.dat file with the command dovecot
+# gives on startup when ssl_dh is unset.
+<%= DovecotCookbook::Conf.attribute(@conf, 'ssl_dh', '</usr/share/dovecot/dh.pem') %>
+
 # SSL protocols to use
 <%= DovecotCookbook::Conf.attribute(@conf, 'ssl_protocols', '!SSLv2') %>
 


### PR DESCRIPTION
### Description

Adds the `ssl_dh` attribute to config, to be able to set Diffie Hellman parameters (required to start on Ubuntu 22.04)

Generated config
```
# SSL DH parameters
# Generate new params with `openssl dhparam -out /etc/dovecot/dh.pem 4096`
# Or migrate from old ssl-parameters.dat file with the command dovecot
# gives on startup when ssl_dh is unset.
#ssl_dh = </etc/dovecot/dh.pem
```

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README and metadata if applicable.

See [CONTRIBUTING.md](https://github.com/zuazo/dovecot-cookbook/blob/master/CONTRIBUTING.md).
